### PR TITLE
Corrected Eventbrite Group Id

### DIFF
--- a/_data/sources/groupIds/eventbrite.js
+++ b/_data/sources/groupIds/eventbrite.js
@@ -1,5 +1,5 @@
 module.exports = [{
-    id: 5881267695,
+    id: 18717122091,
     name: "Creative Informatics",
     img: "https://pbs.twimg.com/profile_images/1073220455035736064/xjepww4M_400x400.jpg",
     url: "https://www.eventbrite.co.uk/o/creative-informatics-18717122091"


### PR DESCRIPTION
Apologies for making it unclear in the documentation, the id property will be the same number at the end of the url. The Id is used to get events from the Eventbrite API, then the URL is just for the links when displayed.